### PR TITLE
Add CBZ selection when creating stories

### DIFF
--- a/app/src/main/java/com/sinhvien/quanlitruyen/DatabaseHelper.java
+++ b/app/src/main/java/com/sinhvien/quanlitruyen/DatabaseHelper.java
@@ -14,13 +14,14 @@ import java.util.List;
 
 public class DatabaseHelper extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "CBZDatabase";
-    private static final int DATABASE_VERSION = 2;
+    private static final int DATABASE_VERSION = 3;
 
     // TABLE TRUYEN
     private static final String TABLE_TRUYEN = "Truyen";
     private static final String COL_MA_TRUYEN = "MaTruyen";
     private static final String COL_TEN_TRUYEN = "TenTruyen";
     private static final String COL_MO_TA = "MoTa";
+    private static final String COL_FILE_HASH = "FileHash";
 
     // TABLE CHUONG
     private static final String TABLE_CHUONG = "Chuong";
@@ -39,7 +40,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         String CREATE_TRUYEN = "CREATE TABLE IF NOT EXISTS " + TABLE_TRUYEN + "("
                 + COL_MA_TRUYEN + " INTEGER PRIMARY KEY AUTOINCREMENT,"
                 + COL_TEN_TRUYEN + " TEXT NOT NULL,"
-                + COL_MO_TA + " TEXT)";
+                + COL_MO_TA + " TEXT,"
+                + COL_FILE_HASH + " TEXT)";
         db.execSQL(CREATE_TRUYEN);
 
         // Bảng chương
@@ -50,21 +52,29 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 + COL_SO_CHUONG + " INTEGER,"
                 + "FOREIGN KEY (" + COL_MA_TRUYEN_FK + ") REFERENCES " + TABLE_TRUYEN + "(" + COL_MA_TRUYEN + ") ON DELETE CASCADE)";
         db.execSQL(CREATE_CHUONG);
+
+        String CREATE_CBZ = "CREATE TABLE IF NOT EXISTS cbz_files (" +
+                "file_hash TEXT, " +
+                "uri TEXT, " +
+                "image_path TEXT)";
+        db.execSQL(CREATE_CBZ);
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         db.execSQL("DROP TABLE IF EXISTS " + TABLE_CHUONG);
         db.execSQL("DROP TABLE IF EXISTS " + TABLE_TRUYEN);
+        db.execSQL("DROP TABLE IF EXISTS cbz_files");
         onCreate(db);
     }
 
     // --- CRUD TRUYEN ---
-    public long insertTruyen(String tenTruyen, String moTa) {
+    public long insertTruyen(String tenTruyen, String moTa, String fileHash) {
         SQLiteDatabase db = this.getWritableDatabase();
         ContentValues values = new ContentValues();
         values.put(COL_TEN_TRUYEN, tenTruyen);
         values.put(COL_MO_TA, moTa);
+        values.put(COL_FILE_HASH, fileHash);
         return db.insert(TABLE_TRUYEN, null, values);
     }
 
@@ -77,7 +87,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 int maTruyen = cursor.getInt(cursor.getColumnIndexOrThrow(COL_MA_TRUYEN));
                 String ten = cursor.getString(cursor.getColumnIndexOrThrow(COL_TEN_TRUYEN));
                 String moTa = cursor.getString(cursor.getColumnIndexOrThrow(COL_MO_TA));
-                list.add(new Truyen(maTruyen, ten, moTa));
+                String hash = cursor.getString(cursor.getColumnIndexOrThrow(COL_FILE_HASH));
+                list.add(new Truyen(maTruyen, ten, moTa, hash));
             } while (cursor.moveToNext());
         }
         cursor.close();

--- a/app/src/main/java/com/sinhvien/quanlitruyen/activity/AddTruyenActivity.java
+++ b/app/src/main/java/com/sinhvien/quanlitruyen/activity/AddTruyenActivity.java
@@ -1,8 +1,13 @@
 package com.sinhvien.quanlitruyen.activity;
 
+import android.app.ProgressDialog;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -10,9 +15,15 @@ import com.sinhvien.quanlitruyen.DatabaseHelper;
 import com.sinhvien.quanlitruyen.R;
 
 public class AddTruyenActivity extends AppCompatActivity {
+    private static final int PICK_CBZ_FILE = 1;
+
     private EditText edtTenTruyen, edtMoTa;
-    private Button btnLuu;
+    private Button btnLuu, btnChonCbz;
+    private TextView txtFileName;
     private DatabaseHelper dbHelper;
+    private ProgressDialog progressDialog;
+    private String fileHash;
+    private java.io.File extractFolder;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -23,6 +34,14 @@ public class AddTruyenActivity extends AppCompatActivity {
         edtTenTruyen = findViewById(R.id.edtTenTruyen);
         edtMoTa = findViewById(R.id.edtMoTa);
         btnLuu = findViewById(R.id.btnLuu);
+        btnChonCbz = findViewById(R.id.btnChonCbz);
+        txtFileName = findViewById(R.id.txtFileName);
+
+        progressDialog = new ProgressDialog(this);
+        progressDialog.setMessage("Đang giải nén...");
+        progressDialog.setCancelable(false);
+
+        btnChonCbz.setOnClickListener(v -> pickCBZFile());
 
         btnLuu.setOnClickListener(v -> {
             String ten = edtTenTruyen.getText().toString().trim();
@@ -31,9 +50,121 @@ public class AddTruyenActivity extends AppCompatActivity {
                 edtTenTruyen.setError("Nhập tên truyện");
                 return;
             }
-            dbHelper.insertTruyen(ten, moTa);
+            if (fileHash == null) {
+                Toast.makeText(this, "Vui lòng chọn file CBZ", Toast.LENGTH_SHORT).show();
+                return;
+            }
+            dbHelper.insertTruyen(ten, moTa, fileHash);
             Toast.makeText(this, "Đã lưu truyện mới!", Toast.LENGTH_SHORT).show();
             finish();
         });
+    }
+
+    private void pickCBZFile() {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        startActivityForResult(Intent.createChooser(intent, "Chọn file CBZ"), PICK_CBZ_FILE);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == PICK_CBZ_FILE && resultCode == RESULT_OK && data != null) {
+            Uri uri = data.getData();
+            if (uri != null) {
+                getContentResolver().takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                txtFileName.setText(uri.getLastPathSegment());
+                new ExtractCBZTask().execute(uri);
+            }
+        }
+    }
+
+    private String calculateFileHash(Uri uri) throws Exception {
+        java.security.MessageDigest md = java.security.MessageDigest.getInstance("MD5");
+        java.io.InputStream is = getContentResolver().openInputStream(uri);
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = is.read(buffer)) > 0) {
+            md.update(buffer, 0, read);
+        }
+        is.close();
+        byte[] digest = md.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private class ExtractCBZTask extends AsyncTask<Uri, Void, Boolean> {
+        @Override
+        protected void onPreExecute() {
+            progressDialog.show();
+        }
+
+        @Override
+        protected Boolean doInBackground(Uri... uris) {
+            try {
+                fileHash = calculateFileHash(uris[0]);
+                extractFolder = new java.io.File(getExternalFilesDir(null), "ExtractedCBZ");
+                if (!extractFolder.exists()) {
+                    extractFolder.mkdirs();
+                } else {
+                    for (java.io.File f : extractFolder.listFiles()) {
+                        f.delete();
+                    }
+                }
+
+                java.io.InputStream inputStream = getContentResolver().openInputStream(uris[0]);
+                java.io.File tmpZip = new java.io.File(getCacheDir(), "temp.cbz");
+                java.io.FileOutputStream out = new java.io.FileOutputStream(tmpZip);
+                byte[] buffer = new byte[8192];
+                int len;
+                while ((len = inputStream.read(buffer)) > 0) {
+                    out.write(buffer, 0, len);
+                }
+                out.close();
+                inputStream.close();
+
+                java.util.zip.ZipFile zipFile = new java.util.zip.ZipFile(tmpZip);
+                java.util.Enumeration<? extends java.util.zip.ZipEntry> entries = zipFile.entries();
+                java.util.List<String> paths = new java.util.ArrayList<>();
+                while (entries.hasMoreElements()) {
+                    java.util.zip.ZipEntry entry = entries.nextElement();
+                    if (!entry.isDirectory()) {
+                        java.io.File outFile = new java.io.File(extractFolder, entry.getName());
+                        java.io.InputStream is = zipFile.getInputStream(entry);
+                        java.io.FileOutputStream fos = new java.io.FileOutputStream(outFile);
+                        while ((len = is.read(buffer)) > 0) {
+                            fos.write(buffer, 0, len);
+                        }
+                        fos.close();
+                        is.close();
+                        if (entry.getName().toLowerCase().endsWith(".jpg") || entry.getName().toLowerCase().endsWith(".png")) {
+                            paths.add(outFile.getAbsolutePath());
+                        }
+                    }
+                }
+                zipFile.close();
+                tmpZip.delete();
+
+                dbHelper.saveCBZFile(fileHash, uris[0].toString(), paths);
+                return !paths.isEmpty();
+            } catch (Exception e) {
+                e.printStackTrace();
+                return false;
+            }
+        }
+
+        @Override
+        protected void onPostExecute(Boolean success) {
+            progressDialog.dismiss();
+            if (!success) {
+                Toast.makeText(AddTruyenActivity.this, "Không tìm thấy ảnh trong file CBZ.", Toast.LENGTH_LONG).show();
+                fileHash = null;
+                txtFileName.setText("Chưa chọn file");
+            }
+        }
     }
 }

--- a/app/src/main/java/com/sinhvien/quanlitruyen/model/Truyen.java
+++ b/app/src/main/java/com/sinhvien/quanlitruyen/model/Truyen.java
@@ -4,14 +4,17 @@ public class Truyen {
     private int maTruyen;
     private String tenTruyen;
     private String moTa;
+    private String fileHash;
 
-    public Truyen(int maTruyen, String tenTruyen, String moTa) {
+    public Truyen(int maTruyen, String tenTruyen, String moTa, String fileHash) {
         this.maTruyen = maTruyen;
         this.tenTruyen = tenTruyen;
         this.moTa = moTa;
+        this.fileHash = fileHash;
     }
 
     public int getMaTruyen() { return maTruyen; }
     public String getTenTruyen() { return tenTruyen; }
     public String getMoTa() { return moTa; }
+    public String getFileHash() { return fileHash; }
 }

--- a/app/src/main/res/layout/activity_add_truyen.xml
+++ b/app/src/main/res/layout/activity_add_truyen.xml
@@ -8,12 +8,25 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
+
     <EditText
         android:id="@+id/edtMoTa"
         android:hint="Mô tả"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:lines="3"/>
+
+    <Button
+        android:id="@+id/btnChonCbz"
+        android:text="Chọn file CBZ"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/txtFileName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Chưa chọn file"/>
 
     <Button
         android:id="@+id/btnLuu"


### PR DESCRIPTION
## Summary
- store CBZ file hash in database
- create table to cache extracted images
- update model `Truyen` to hold file hash
- allow choosing a CBZ file when adding a story and save extracted images
- show selected file in AddTruyen UI

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68519971b62883328248a5205740c037